### PR TITLE
[Feature] Better sum types

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,5 +143,43 @@ Use `maxProperties:"number"`, `minProperties:"number"` to restrict the number of
 
 You can also customize entire types.
 
-See all the interfaces in `hooks` to see how to document entire types, including the complex
-case of sum types.
+### Sum types
+
+Sum types (e.g. `int | string`) are very different between Go and OpenSpec.
+
+In Go, se represent the sum type as a `struct`, e.g.
+
+```go
+type MyFooOrBar struct {
+    Foo* Foo `variant:"variant_1" json:"foo"`
+    Bar* Bar `variant:"variant_2" json:"bar"`
+}
+```
+
+This will be compiled as if we had defined
+
+```ts
+type MyFooOrBar = {Foo* Foo} | {Bar* Bar}
+```
+
+Alternatively, you can request flattening
+
+```go
+type MyFooOrBar struct {
+    Foo* Foo `variant:"variant_1" json:"foo" flatten:""`
+    Bar* Bar `variant:"variant_2" json:"bar"  flatten:""`
+}
+```
+
+This will be compiled as if we had defined
+
+```ts
+type MyFooOrBar = Foo | Bar
+```
+
+As of this writing, this mechanism only works if `Foo` or `Bar` are `struct`. If you
+need it to work with other types, don't hesitate to file an issue!
+
+### Min, max, pattern, length, ...
+
+See all the interfaces in `hooks` to see how to document entire types.

--- a/inner/tags/tags.go
+++ b/inner/tags/tags.go
@@ -256,3 +256,7 @@ func (tags Tags) LookupInt(key string) (*int64, error) {
 func (tags Tags) Example() *string {
 	return tags.LookupString("example")
 }
+
+func (tags Tags) Variants() ([]string, bool) {
+	return tags.Lookup("variant")
+}

--- a/openapi/hooks/hooks.go
+++ b/openapi/hooks/hooks.go
@@ -28,9 +28,6 @@ type HasSchema = schema.HasSchema
 // Implement this on enums of constants to let gousset list all the possibilities.
 type HasEnum = schema.IsEnum
 
-// Implement this on sum types to let gousset list all the possibilities.
-type IsOneOf = schema.IsOneOf
-
 // Implement this on numbers or strings to restrict to a specific format.
 type HasFormat = schema.HasFormat
 


### PR DESCRIPTION
Throwing away the previous implementation of sum types, which was quite complex and didn't quite work.

We can now declare sum types with
```go
type MySumType struct {
     Field1* int `variant:"one"`
     Field2* string `variant:"two, three"`
     Field3* bool `variant:"three"`
}
```

which will produce the OpenAPI spec for

```ts
type MySumType =
  { Field1: int }
|{ Field2: string }
| {Field2: string, Field3: bool }
```